### PR TITLE
Trace evaluation event hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,65 @@ When you are done inspecting things, run ``continue`` (or short-hand ``c``) to r
     Out[3]= 2.71828
 
 
+Improved TraceEvaluation
+------------------------
+
+As before, install ``mathics3-debugger``. To set up tracing ``.evaluate()`` calls::
+
+    In[1]:= LoadModule["pymathics.debugger"]
+    Out[1]= "pymathics.debugger"
+
+    In[2]:= TraceActivate[evaluate->True]
+    Out[2]=
+
+In contrast to ``DebugActivate``, ``TraceActivate`` just prints or traces events.
+
+Now we are ready for some action::
+
+    In[3]:= (x + 1) ^ 2
+    Evaluating: Power[Plus[x, 1], 2]
+
+      Evaluating: Plus[x, 1]
+
+      Returning: Plus[x, 1] = Plus[1, x]
+
+      Evaluating: Plus[1, x]
+
+    Returning: Power[Plus[x, 1], 2] = Power[Plus[1, x], 2]
+
+    Out[3]= (1 + x) ^ 2
+
+Above we trace before an ``evaluate()`` method call and also sometimes show the return value.
+
+To reduce the unecessary output, evaluations when it has some value. In particular, above there is an evaluation of the Symbols "Power", and "Plus", The result of evaluating these is basically the same symbol. So we don't show either ``Evaluating: Power`` and ``Returning: Power``. Simlarly we omit the same for ``Plus``.
+
+We also omit ``Returning: Plus[1, x]`` because ``Plus[1, x]`` is the same expression as went in.
+But notice we *do* show ``Returning: Plus[x, 1] = Plus[1, x]``. Here the difference is that the order of the parameters got rearranged. Perhaps this is not interesting either, but currently it is shown.
+
+Now let's do the same thing but set the value of ``x``::
+
+   In[4]:= x = 3
+   Evaluating: Set[x, 3]
+
+   Returning: Set[x, 3] = 3
+
+   Out[4]= 3
+
+   In[5]:= (x + 1) ^ 2
+   Evaluating: Power[Plus[x, 1], 2]
+
+     Evaluating: Plus[x, 1]
+
+       Returning: x = 3
+
+     Returning: Plus[x, 1] = 4
+
+   Returning: Power[Plus[x, 1], 2] = 16
+
+   Out[5]= 16
+
+Here, the return values have the computed Integer values from evaluation as you'd expect to see when working with Integer values instead of mixed symbolic and Integer values.
+
 Post-mortem debugging
 ---------------------
 

--- a/pymathics/debugger/__main__.py
+++ b/pymathics/debugger/__main__.py
@@ -159,7 +159,7 @@ class DebugActivate(Builtin):
                     apply_builtin_fn_traced if event_is_debugged else EVALUATION_APPLY
                 )
             elif event_name == "evaluate":
-                event_filters["evaluate"] = filters
+                event_filters["evaluate-entry"] = event_filters["evaluate-result"] = filters
                 tracing.trace_evaluate_on_return = tracing.trace_evaluate_on_call = (
                     debug_evaluate if event_is_debugged else None
                 )

--- a/pymathics/debugger/__main__.py
+++ b/pymathics/debugger/__main__.py
@@ -20,14 +20,16 @@ from mathics.core.symbols import SymbolFalse, SymbolTrue
 
 from pymathics.debugger.tracing import (
     TraceEventNames,
-    apply_builtin_box_fn_traced,
+    # apply_builtin_box_fn_traced,
     apply_builtin_fn_print,
     apply_builtin_fn_traced,
     call_event_debug,
     call_event_get,
     call_trepan3k,
+    debug_evaluate,
     event_filters,
     pre_evaluation_debugger_hook,
+    trace_evaluate,
 )
 
 from typing import Dict, Optional, Tuple
@@ -39,6 +41,7 @@ EVENT_OPTIONS: Dict[str, str] = {
     "SymPy": "False",
     "apply": "False",
     "applyBox": "False",
+    "evaluate": "False",
     "evalMethod": "False",
     "evalFunction": "False",
     "mpmath": "False",
@@ -154,6 +157,11 @@ class DebugActivate(Builtin):
             elif event_name == "apply":
                 FunctionApplyRule.apply_function = (
                     apply_builtin_fn_traced if event_is_debugged else EVALUATION_APPLY
+                )
+            elif event_name == "evaluate":
+                event_filters["evaluate"] = filters
+                tracing.trace_evaluate_on_return = tracing.trace_evaluate_on_call = (
+                    debug_evaluate if event_is_debugged else None
                 )
 
             elif event_name == "evalMethod":
@@ -287,6 +295,11 @@ class TraceActivate(Builtin):
             elif event_name == "apply":
                 FunctionApplyRule.apply_function = (
                     apply_builtin_fn_print if event_is_traced else EVALUATION_APPLY
+                )
+            elif event_name == "evaluate":
+                event_filters["evaluate"] = filters
+                tracing.trace_evaluate_on_return = tracing.trace_evaluate_on_call = (
+                   trace_evaluate if event_is_traced else None
                 )
             elif event_name == "evalMethod":
                 event_filters["evalMethod"] = filters

--- a/pymathics/debugger/__main__.py
+++ b/pymathics/debugger/__main__.py
@@ -109,6 +109,10 @@ class DebugActivate(Builtin):
                         evaluation.message("DebugActivate", "opttname", option)
                         return None, False
                     # TODO: check that string is a valid {mpmath, SymPy, Numpy} name.
+                    # THINK ABOUT: if a filter value is a short name, e.g. "Plus" instead of
+                    # "System`Plus", should we try to fill in the full name? Or use "Plus"
+                    # as a way to match any "XXX`YYY..`Plus" that might appear in any
+                    # context in the future.
                     filters.append(elt.value)
                 return filters, True
             elif option in (SymbolTrue, SymbolFalse):

--- a/pymathics/debugger/lib/core.py
+++ b/pymathics/debugger/lib/core.py
@@ -417,7 +417,6 @@ class DebuggerCore:
                 return None
 
             self.event = event
-            print("XXX")
             if self.debugger.settings["trace"]:
                 print_event_set = self.debugger.settings["printset"]
                 if self.event in print_event_set:

--- a/pymathics/debugger/lib/core.py
+++ b/pymathics/debugger/lib/core.py
@@ -461,6 +461,17 @@ class DebuggerCore:
                     file_path, call_args = arg
                     if file_path not in event_filter and event_filter:
                         return
+                elif event == "evaluate-result":
+                    orig_expr = arg[-1]
+                    if orig_expr.get_name(short=True) not in event_filter:
+                        return
+                elif event == "evaluate-entry":
+                    expr = arg[0]
+                    if expr.get_name(short=True) not in event_filter:
+                        return
+                else:
+                    print(f"FIXME: Unhandlied event {event}")
+
 
 
             return self.processor.event_processor(frame, event, arg)

--- a/pymathics/debugger/lib/core.py
+++ b/pymathics/debugger/lib/core.py
@@ -463,16 +463,20 @@ class DebuggerCore:
                         return
                 elif event == "evaluate-result":
                     orig_expr = arg[-1]
-                    if orig_expr.get_name(short=True) not in event_filter:
+                    # If any of the evaluation-result filters uses a short name, then we will take the
+                    # short name of the original expression.
+                    # TODO: Think about if we should allow short names in event filters or whether we should
+                    # always fill those in based on $Context or $ContextPath.
+                    use_short = all(name.find("`") == -1 for name in event_filter)
+                    if orig_expr.get_name(short=use_short) not in event_filter:
                         return
                 elif event == "evaluate-entry":
                     expr = arg[0]
-                    if expr.get_name(short=True) not in event_filter:
+                    if expr.get_name() not in event_filter:
                         return
                 else:
-                    print(f"FIXME: Unhandlied event {event}")
-
-
+                    print(f"FIXME: Unhandled event {event}")
+                    return
 
             return self.processor.event_processor(frame, event, arg)
         # except ReturnChanged:

--- a/pymathics/debugger/lib/repl.py
+++ b/pymathics/debugger/lib/repl.py
@@ -65,7 +65,9 @@ class DebugREPL:
             "Get",  # Get[]
             "SymPy",  # SymPy call
             "apply",  # Builtin function call
-            "evalMethod", # calling a builti-in evaluation method Class.eval_xxx()
+            "evaluate-entry", # before evaluate()
+            "evaluate-result", # after evaluate()
+            "evalMethod", # calling a built-in evaluation method Class.eval_xxx()
             "debugger",  # explicit call via "Debugger"
             "mpmath",  # mpmath call
             }

--- a/pymathics/debugger/lib/stack.py
+++ b/pymathics/debugger/lib/stack.py
@@ -30,7 +30,7 @@ from trepan.lib.stack import (
     format_function_name,
     format_return_and_location,
     get_call_function_name,
-    is_exec_stmt,
+    is_eval_exec_stmt,
 )
 from mathics.core.builtin import Builtin
 from mathics.core.element import BaseElement
@@ -89,15 +89,14 @@ def format_function_and_parameters(frame, debugger, style: str) -> Tuple[bool, s
         varkw,
     ):
         is_module = True
-        if is_exec_stmt(frame):
-            fn_name = format_token(Function, "exec", style=style)
-            s += f" {format_token(Function, fn_name, style=style)}(...)"
+        if (func_name := is_eval_exec_stmt(frame)):
+            s += f" {format_token(Function, func_name, style=style)}(...)"
         else:
             # FIXME: package the below as a function in trepan3k
-            fn_name = get_call_function_name(frame)
-            if fn_name:
-                if fn_name:
-                    s += f" {format_token(Function, fn_name, style=style)}({...})"
+            func_name = get_call_function_name(frame)
+            if func_name:
+                if func_name:
+                    s += f" {format_token(Function, func_name, style=style)}({...})"
             pass
     else:
         is_module = False

--- a/pymathics/debugger/processor/cmdproc.py
+++ b/pymathics/debugger/processor/cmdproc.py
@@ -400,6 +400,8 @@ class CommandProcessor(Processor):
         self.event2short["signal"] = "?!"
         self.event2short["apply"] = "@@"
         self.event2short["evalMethod"] = "@m"
+        self.event2short["evaluate-entry"] = "@e"
+        self.event2short["evaluate-result"] = "e@"
         self.event2short["evalFunction"] = "@f"
         self.event2short["brkpt"] = "xx"
         self.event2short["debugger"] = "$ "

--- a/pymathics/debugger/tracing.py
+++ b/pymathics/debugger/tracing.py
@@ -1,12 +1,13 @@
 import inspect
 import re
+import time
 from enum import Enum
 from typing import Callable
 
 import mathics.eval.tracing as eval_tracing
 from mathics.core.evaluation import Evaluation
 from mathics.core.rules import FunctionApplyRule
-from mathics.core.symbols import strip_context
+from mathics.core.symbols import Symbol, strip_context
 from trepan.debugger import Trepan
 
 from pymathics.debugger.lib.format import format_element, pygments_format
@@ -21,7 +22,8 @@ TraceEventNames = (
     "SymPy",  # traps calls to SymPy functions
     "apply",  # applying a function that is *not* a Boxing function
     "applyBox",  # applying a function that *is* a Boxing function
-    "evalMethod",  # calling a builti-in evaluation method Class.eval_xxx()
+    "evaluate",  # calling an evaluate() method, e.g. Expression.evaluate()
+    "evalMethod",  # calling a built-in evaluation method Class.eval_xxx()
     "evalFunction",  # calling an evaluation  eval_Xxx() of mathics.eval
     "mpmath",  # traps calls to mpmath functions
     "parse",  # traps calls to parse()
@@ -40,6 +42,7 @@ event_filters: Dict[str, List[str]] = {
     "SymPy": [],
     "apply": [],
     "applyBox": [],
+    "evaluate": [],
     "evalMethod": [],
     "evalFunction": [],
     "mpmath": [],
@@ -222,7 +225,29 @@ def call_trepan3k(proc_obj):
     return
 
 
-def traced_eval_method(method_name: str, *args, **kwargs):
+def debug_evaluate(self, evaluation, status: str, orig_expr = None):
+    """
+    Called from a decorated Python @trace_evaluate .evaluate()
+    method when DebugActivate["evaluate" -> True]
+    """
+    global dbg
+    if dbg is None:
+        from pymathics.debugger.lib.repl import DebugREPL
+
+        dbg = DebugREPL()
+
+    current_frame = inspect.currentframe()
+    if current_frame is not None:
+        current_frame = current_frame.f_back
+        if current_frame is not None:
+            current_frame = current_frame.f_back
+
+    dbg.core.execution_status = "Running"
+    event_str = "evaluate-entry" if status == "Evaluating" else "evaluate-result"
+    dbg.core.trace_dispatch(current_frame, event_str, (self, evaluation, status, orig_expr))
+
+
+def debug_eval_method(method_name: str, *args, **kwargs):
     global dbg
     if dbg is None:
         from pymathics.debugger.lib.repl import DebugREPL
@@ -250,10 +275,9 @@ def pre_evaluation_debugger_hook(query, evaluation: Evaluation):
     print("Pre evaluation hook called")
     for method in event_filters["evalMethod"]:
         if method == "message":
-            from trepan.api import debug; debug()
             if saved_methods.get(method) is None:
                 saved_methods[method] = evaluation.message
-            evaluation.message = traced_eval_method
+            evaluation.message = debug_eval_method
         else:
             definition = evaluation.definitions.get_definition(
                 method, only_if_exists=True
@@ -267,9 +291,43 @@ def pre_evaluation_debugger_hook(query, evaluation: Evaluation):
                         if saved_methods.get(method) is None:
                             saved_methods[method] = value.apply_function
                         value.apply_function = (
-                            lambda *args, **kwargs: traced_eval_method(
+                            lambda *args, **kwargs: debug_eval_method(
                                 method, *args, **kwargs
                             )
                         )
 
     return
+
+def trace_evaluate(expr, evaluation, status: str, orig_expr = None):
+    """
+    Print what's up with an evaluation. In contrast to debug_evaluate,
+    we don't stop execution and go into a debugger.
+
+    Called from a decorated Python @trace_evaluate .evaluate()
+    method when TraceActivate["evaluate" -> True]
+    """
+    if evaluation.definitions.timing_trace_evaluation:
+        evaluation.print_out(time.time() - evaluation.start_time)
+
+    if isinstance(expr, Symbol):
+        return
+
+    global dbg
+    if dbg is None:
+        from pymathics.debugger.lib.repl import DebugREPL
+
+        dbg = DebugREPL()
+
+    style = dbg.settings["style"]
+    formatted_expr = format_element(expr)
+    msg = dbg.core.processor.msg
+    indents = "  " * evaluation.recursion_depth
+    if orig_expr is not None and orig_expr != expr:
+        formatted_orig_expr = format_element(orig_expr)
+        msg(
+             f"{indents}{status}: {pygments_format(formatted_orig_expr + ' = ' + formatted_expr, style)}"
+        )
+    else:
+        msg(
+             f"{indents}{status}: {pygments_format(formatted_expr, style)}"
+        )

--- a/pymathics/debugger/tracing.py
+++ b/pymathics/debugger/tracing.py
@@ -7,7 +7,7 @@ from typing import Callable
 import mathics.eval.tracing as eval_tracing
 from mathics.core.evaluation import Evaluation
 from mathics.core.rules import FunctionApplyRule
-from mathics.core.symbols import Symbol, strip_context
+from mathics.core.symbols import Symbol, SymbolConstant, strip_context
 from trepan.debugger import Trepan
 
 from pymathics.debugger.lib.format import format_element, pygments_format
@@ -319,7 +319,7 @@ def trace_evaluate(expr, evaluation, status: str, orig_expr=None):
     # is pretty useless: evaluationg a Symbol is the Symbol.
     # Showing the return value of a ListExpression literal is
     # also useless.
-    if isinstance(expr, Symbol):
+    if isinstance(expr, Symbol) and not isinstance(expr, SymbolConstant):
         return
 
     if (

--- a/pymathics/debugger/tracing.py
+++ b/pymathics/debugger/tracing.py
@@ -42,7 +42,8 @@ event_filters: Dict[str, List[str]] = {
     "SymPy": [],
     "apply": [],
     "applyBox": [],
-    "evaluate": [],
+    "evaluate-entry": [],  # Before evaluate()
+    "evaluate-result": [],  # After evaluate() when we have a value
     "evalMethod": [],
     "evalFunction": [],
     "mpmath": [],


### PR DESCRIPTION
This hooks into recent work to redo TraceEvaluation via a trace-hook decorator. 

This can only be merged after https://github.com/Mathics3/mathics3-debugger/pull/6/commits/49b03caf4fefda9151fd3b8c1873f2b79630f83e and also see the discussion https://github.com/Mathics3/mathics-core/discussions/1168#discussioncomment-11281866 which includes the use of this.